### PR TITLE
Hotfix/capabilites

### DIFF
--- a/docker/driver.go
+++ b/docker/driver.go
@@ -75,6 +75,11 @@ func (d Driver) List(r volume.Request) volume.Response {
 	return volume.Response{Volumes: vols}
 }
 
+// Capabilities tells Docker that data is stored locally
+func (d Driver) Capabilities(r volume.Request) volume.Response {
+	return volume.Response{Capabilities: volume.Capability{Scope: "local"}}
+}
+
 // Remove handles volume removal calls
 func (d Driver) Remove(r volume.Request) volume.Response {
 	d.m.Lock()

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -70,12 +70,12 @@ func (v *VaultFS) Unmount() error {
 		return errors.New("not mounted")
 	}
 
-	err = v.conn.Close()
+	err := v.conn.Close()
 	if err != nil {
 		return err
 	}
 
-	err := fuse.Unmount(v.mountpoint)
+	err = fuse.Unmount(v.mountpoint)
 	if err != nil {
 		return err
 	}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -70,12 +70,12 @@ func (v *VaultFS) Unmount() error {
 		return errors.New("not mounted")
 	}
 
-	err := v.conn.Close()
+	err := fuse.Unmount(v.mountpoint)
 	if err != nil {
 		return err
 	}
 
-	err = fuse.Unmount(v.mountpoint)
+	err = v.conn.Close()
 	if err != nil {
 		return err
 	}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -70,12 +70,12 @@ func (v *VaultFS) Unmount() error {
 		return errors.New("not mounted")
 	}
 
-	err := fuse.Unmount(v.mountpoint)
+	err = v.conn.Close()
 	if err != nil {
 		return err
 	}
 
-	err = v.conn.Close()
+	err := fuse.Unmount(v.mountpoint)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The package "github.com/docker/go-plugins-helpers/volume" extended the Driver Interface to have a "Capabilities" method that tells docker whether the volume keeps data on the host or in the container. I added the method so it doesn't break. 
